### PR TITLE
fix: link 404 Not Found

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 
 ## 快速开始
-前往 [微信云托管快速开始页面](https://developers.weixin.qq.com/miniprogram/dev/wxcloudrun/src/basic/guide.html)，选择相应语言的模板，根据引导完成部署。
+前往 [微信云托管快速开始页面](https://developers.weixin.qq.com/miniprogram/dev/wxcloudrun/src/quickstart/template)，选择相应语言的模板，根据引导完成部署。
 
 ## 本地调试
 下载代码在本地调试，请参考[微信云托管本地调试指南](https://developers.weixin.qq.com/miniprogram/dev/wxcloudrun/src/guide/debug/)


### PR DESCRIPTION
[微信云托管快速开始页面](https://developers.weixin.qq.com/miniprogram/dev/wxcloudrun/src/basic/guide.html) 404 Not Found